### PR TITLE
Fixed error in v2City object Test

### DIFF
--- a/app/code/community/ExtensionsStore/Addressvalidator/Model/Service/Fedex.php
+++ b/app/code/community/ExtensionsStore/Addressvalidator/Model/Service/Fedex.php
@@ -183,7 +183,7 @@ class ExtensionsStore_Addressvalidator_Model_Service_Fedex extends ExtensionsSto
                     $countryId = $addressData->CountryCode;
                     $country = $addressData->CountryCode;
                     $street = array($addressData->StreetLines);
-                    $city = ($addressData->v2City) ? $addressData->v2City : $addressData->City;
+                    $city = (isset($addressData->v2City)) ? $addressData->v2City : $addressData->City;
                     $regionModel = Mage::getModel('directory/region');
                     $regionModel->loadByCode($addressData->StateOrProvinceCode, $countryId);
                     $regionName = $regionModel->getName();


### PR DESCRIPTION
If the object `v2City` didn't exist it would throw the exception:

`Undefined property: stdClass::$v2City`

In order to fix this you must check and see if `v2City` is set.

Tested on PHP 7.0